### PR TITLE
Markupsafe breaks with the latest version of setuptools:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ Flask==1.0.2
 gunicorn==19.9.0
 itsdangerous==0.24
 Jinja2==2.10
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 Werkzeug==0.14.1


### PR DESCRIPTION
App runs fine with python 3.9 after upgrading.
https://github.com/pallets/markupsafe/issues/116#issuecomment-596543010